### PR TITLE
[update]refs #19 style.cssの.pageTitleとpが汎用性を持つように変更

### DIFF
--- a/common/css/style.css
+++ b/common/css/style.css
@@ -85,12 +85,8 @@ a:active {
     background: #fff;
 }
 
-/* section paragraph */
-/* -------------------------------------------- */
-
 /* page title */
-#sec_paragraph .pageTitle {
-    margin-top: 2.7em;
+#pageMain .articleDetail .pageTitle {
     font-size: 1.8em;
     font-weight: 900;
     text-align: center;
@@ -98,9 +94,14 @@ a:active {
 }
 
 /* paragraph */
-#sec_paragraph p {
+#pageMain .articleDetail p {
     font-size: 1.2em;
     font-weight: 400;
     line-height: 1.3;
     letter-spacing: .02em;
+}
+
+/* section paragraph */
+#pageMain .articleDetail #sec_paragraph {
+    margin-top: 4.9em;
 }


### PR DESCRIPTION
#sec_paragraph限定の装飾から、.articleDetail全体の装飾に変更
それに伴い、.pageTitleのmargin-topを#sec_paragraph限定のものに変更
This merge resolves #19.